### PR TITLE
mass assignment fix

### DIFF
--- a/app/models/sidekiq/monitor/job.rb
+++ b/app/models/sidekiq/monitor/job.rb
@@ -3,7 +3,7 @@ module Sidekiq
     class Job < ActiveRecord::Base
       require 'rubygems'
       
-      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || Gem::Specification.all().map{|g| g.name}.include?("protected_attributes")
+      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || ActiveRecord.constants.include? :MassAssignmentSecurity
 
       serialize :args
       serialize :result

--- a/app/models/sidekiq/monitor/job.rb
+++ b/app/models/sidekiq/monitor/job.rb
@@ -3,7 +3,7 @@ module Sidekiq
     class Job < ActiveRecord::Base
       require 'rubygems'
       
-      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || ActiveRecord.constants.include? :MassAssignmentSecurity
+      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || ::ActiveRecord.constants.include? :MassAssignmentSecurity
 
       serialize :args
       serialize :result

--- a/app/models/sidekiq/monitor/job.rb
+++ b/app/models/sidekiq/monitor/job.rb
@@ -1,9 +1,9 @@
 module Sidekiq
   module Monitor
     class Job < ActiveRecord::Base
-      require 'rubygems'
+      require 'active_record'
       
-      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || ::ActiveRecord.constants.include? :MassAssignmentSecurity
+      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || ActiveRecord.constants.include? :MassAssignmentSecurity
 
       serialize :args
       serialize :result

--- a/app/models/sidekiq/monitor/job.rb
+++ b/app/models/sidekiq/monitor/job.rb
@@ -1,9 +1,9 @@
 module Sidekiq
   module Monitor
     class Job < ActiveRecord::Base
-      require 'active_record'
+      require 'rubygems'
       
-      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || ActiveRecord.constants.include?(:MassAssignmentSecurity)
+      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || Gem::Specification.all().map{|g| g.name}.include?("protected_attributes")
 
       serialize :args
       serialize :result

--- a/app/models/sidekiq/monitor/job.rb
+++ b/app/models/sidekiq/monitor/job.rb
@@ -1,9 +1,9 @@
 module Sidekiq
   module Monitor
     class Job < ActiveRecord::Base
-      require 'rubygems'
+      require 'active_record'
       
-      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || Gem::Specification.all().map{|g| g.name}.include?("protected_attributes")
+      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || ActiveRecord.constants.include?(:MassAssignmentSecurity)
 
       serialize :args
       serialize :result

--- a/app/models/sidekiq/monitor/job.rb
+++ b/app/models/sidekiq/monitor/job.rb
@@ -3,7 +3,7 @@ module Sidekiq
     class Job < ActiveRecord::Base
       require 'active_record'
       
-      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || ActiveRecord.constants.include? :MassAssignmentSecurity
+      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || ActiveRecord.constants.include?(:MassAssignmentSecurity)
 
       serialize :args
       serialize :result

--- a/app/models/sidekiq/monitor/job.rb
+++ b/app/models/sidekiq/monitor/job.rb
@@ -1,7 +1,9 @@
 module Sidekiq
   module Monitor
     class Job < ActiveRecord::Base
-      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4
+      require 'rubygems'
+      
+      attr_accessible :args, :class_name, :enqueued_at, :finished_at, :jid, :name, :queue, :result, :retry, :started_at, :status if ActiveRecord::VERSION::MAJOR < 4 || Gem::Specification.all().map{|g| g.name}.include?("protected_attributes")
 
       serialize :args
       serialize :result


### PR DESCRIPTION
Use attr_accessible on Rails 4 if the "protected_attributes" gem is in use. Resolves #13.
