### PR TITLE
Require jquery-datatables-rails 2.1.10.0.2 and fix js path

### DIFF
--- a/app/assets/stylesheets/sidekiq/monitor/application.css.sass
+++ b/app/assets/stylesheets/sidekiq/monitor/application.css.sass
@@ -1,5 +1,5 @@
 @import sidekiq/monitor/bootstrap.min
 @import sidekiq/monitor/bootstrap-select.min
-@import dataTables/jquery.dataTables.bootstrap
+@import dataTables/bootstrap/2/jquery.dataTables.bootstrap
 @import sidekiq/monitor/layout
 @import sidekiq/monitor/jobs_table

--- a/sidekiq_monitor.gemspec
+++ b/sidekiq_monitor.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "sidekiq", ">= 2.2.1"
   s.add_dependency "slim"
-  s.add_dependency "jquery-datatables-rails"
+  s.add_dependency "jquery-datatables-rails", ">= 2.1.10.0.2"
   s.add_dependency "rails-datatables"
 end


### PR DESCRIPTION
This fixes #27 by updating the jquery-datatables-rails dependency to >= 2.1.10.0.2 and fixing the path to the jquery.dataTables.bootstrap file.
